### PR TITLE
Add an on-types rule to allow multiple types down one path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ pom.xml.asc
 *.ipr
 *.iws
 .idea
+lsp/

--- a/src/vent/core.clj
+++ b/src/vent/core.clj
@@ -4,7 +4,8 @@
 
     [vent.util
      :refer [invoke-highest-arity
-             deep-merge]]))
+             deep-merge]])
+  (:import [java.util Collection]))
 
 (declare rule->plan)
 
@@ -121,6 +122,11 @@
 (defn on-type [event-type & handlers]
   {:rule-matching-fn (fn [event {:keys [event-type-fn]}]
                        (= event-type (event-type-fn event)))
+   :handlers         handlers})
+
+(defn on-types [^Collection event-types & handlers]
+  {:rule-matching-fn (fn [event {:keys [event-type-fn]}]
+                       (.contains event-types (event-type-fn event)))
    :handlers         handlers})
 
 (defn on-every [& handlers]


### PR DESCRIPTION
This uses java `contains` as `contains?` does not check if a value is present and using `some` either needs an equality operator or the use of sets.

Authors: @alexparlett