### PR TITLE
Allow propagating action output in context for chaining actions

### DIFF
--- a/src/vent/core.clj
+++ b/src/vent/core.clj
@@ -180,8 +180,14 @@
           :context (add-context-to implementation context))
 
         (= type :action)
-        (update-in accumulator
-          [:outputs] conj (execute implementation context))
+        (let [output (execute implementation context)
+              pipe-output? (and
+                             (map? output)
+                             (-> output meta :ignore not))]
+          (-> accumulator
+            (update-in [:outputs] conj output)
+            (merge (when pipe-output?
+                     {:context (deep-merge context output)}))))
 
         (= type :choice)
         (if-let [selected-option


### PR DESCRIPTION
**original proposal: new piped-action**

This patch introduces a new step type, "piped-action",
and the related ruleset function "act-and-gather". They
enable propagating the outcome of an action via the
"context" map.

The use case for this change is chaining actions (A --> B),
where the logic of B relies on the outcome of A;
before this patch such behaviour was only possible by
defining A as a "gatherer", which effectively broke the
implicit semantics of the library: 1) no result on
"outputs" for such action gatherer and 2) using a
gatherer for a procedure that may introduce state changes.

Note that the intent of naming the high level ruleset function
as "act-and-gather" is to suggest that the returned value
of the handler should be a map in order to be propagated
via "context" (same as for the "gatherer" interface),
otherwise the result is only appended to the "outputs" array.