### PR TITLE
Remove halboy dependency from lib

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,15 +4,15 @@
   :license {:name "The MIT License"
             :url  "https://opensource.org/licenses/MIT"}
   :dependencies [[org.clojure/clojure "1.10.0"]
-                 [medley "1.0.0"]
-                 [halboy "4.0.1"]]
+                 [medley "1.0.0"]]
   :plugins [[lein-eftest "0.5.3"]
             [lein-changelog "0.3.2"]
             [lein-shell "0.5.0"]
             [lein-codox "0.10.7"]]
   :profiles {:shared {:dependencies [[faker "0.3.2"]
                                      [clj-fakes "0.11.0"]
-                                     [eftest "0.5.3"]]}
+                                     [eftest "0.5.3"]
+                                     [halboy "6.0.1"]]}
              :dev    [:shared]
              :test   [:shared]}
 

--- a/src/vent/hal.clj
+++ b/src/vent/hal.clj
@@ -3,11 +3,15 @@
     [clojure.string :as string]))
 
 (defn- single-word
-    "Removes spaces from property and creates a single word joined by '-'"
+  "Removes spaces from property and creates a single word joined by '-'"
   [property]
   (if (string? property)
     (string/join "-" (string/split property #"(\s+)"))
     property))
 
-(defn event-type-property [property]
+(defn event-type-property
+  "Returns a function that generates an event-type kebab-case keyword from an event's specified `property`.
+
+  The assumption is that this event has a :payload which contains a halboy-formatted HAL resource."
+  [property]
   (fn [event] (keyword (single-word (get-in event [:payload :properties property])))))

--- a/src/vent/hal.clj
+++ b/src/vent/hal.clj
@@ -2,8 +2,9 @@
   (:require
     [clojure.string :as string]))
 
-(defn- single-word [property]
-  "Removes spaces from property and creates a single word joined by '-'"
+(defn- single-word
+    "Removes spaces from property and creates a single word joined by '-'"
+  [property]
   (if (string? property)
     (string/join "-" (string/split property #"(\s+)"))
     property))

--- a/src/vent/hal.clj
+++ b/src/vent/hal.clj
@@ -1,6 +1,5 @@
 (ns vent.hal
   (:require
-    [halboy.resource :as hal]
     [clojure.string :as string]))
 
 (defn- single-word [property]
@@ -10,4 +9,4 @@
     property))
 
 (defn event-type-property [property]
-  (fn [event] (keyword (single-word (hal/get-property (:payload event) property)))))
+  (fn [event] (keyword (single-word (get-in event [:payload :properties property])))))


### PR DESCRIPTION
Maintains the vent.hal namespace but does manual key access instead so that the rest of vent can be used in services that don't use halboy without pulling it in as an additional dependency.